### PR TITLE
github/workflow: Run on PRs and unify definition

### DIFF
--- a/.github/workflows/archlinux.yaml
+++ b/.github/workflows/archlinux.yaml
@@ -1,8 +1,17 @@
 name: Build Arch Linux toolbx image
 
+permissions: read-all
+
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
+    paths:
+      - archlinux/**
+      - .github/workflows/archlinux.yaml
+  pull_request:
+    branches:
+      - main
     paths:
       - archlinux/**
       - .github/workflows/archlinux.yaml
@@ -12,6 +21,9 @@ on:
 # Prevent multiple workflow runs from racing
 concurrency: ${{ github.workflow }}
 
+env:
+  distro: 'archlinux'
+  distro_pretty: 'Arch Linux'
 jobs:
   build-and-push-images:
     name: Build and push images
@@ -26,16 +38,28 @@ jobs:
 
       - name: Login to Quay.io
         uses: docker/login-action@v2
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main'
         with:
           registry: quay.io
           username: 'toolbx-images+github'
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      - name: Build and push Arch Linux toolbx image
+      - name: Build ${{ env.distro_pretty }} ${{ matrix.release }} toolbox image
+        uses: docker/build-push-action@v3
+        if: github.event_name == 'pull_request'
+        with:
+          context: ${{ env.distro }}
+          file: ${{ env.distro }}/Containerfile
+          platforms: linux/amd64
+          push: false
+          tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:latest
+
+      - name: Build and push ${{ env.distro_pretty }} toolbx image
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main'
         uses: docker/build-push-action@v3
         with:
-          context: archlinux
-          file: archlinux/Containerfile
+          context: ${{ env.distro }}
+          file: ${{ env.distro }}/Containerfile
           platforms: linux/amd64
           push: true
-          tags: quay.io/toolbx-images/archlinux-toolbox:latest
+          tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:latest

--- a/.github/workflows/centos.yaml
+++ b/.github/workflows/centos.yaml
@@ -1,8 +1,17 @@
 name: Build CentOS Stream toolbx images
 
+permissions: read-all
+
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
+    paths:
+      - centos/**
+      - .github/workflows/centos.yaml
+  pull_request:
+    branches:
+      - main
     paths:
       - centos/**
       - .github/workflows/centos.yaml
@@ -13,13 +22,15 @@ on:
 concurrency: ${{ github.workflow }}
 
 env:
-  latest_centos_release: 'stream9'
+  distro: 'centos'
+  distro_pretty: 'CentOS'
+  latest_release: 'stream9'
 
 jobs:
   build-and-push-images:
     strategy:
       matrix:
-        centos_release: ['stream8', 'stream9']
+        release: ['stream8', 'stream9']
 
     runs-on: ubuntu-latest
     steps:
@@ -34,26 +45,38 @@ jobs:
 
       - name: Login to Quay.io
         uses: docker/login-action@v2
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main'
         with:
           registry: quay.io
           username: 'toolbx-images+github'
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      - name: Build and push CentOS ${{ matrix.centos_release }} toolbox image
+      - name: Build ${{ env.distro_pretty }} ${{ matrix.release }} toolbox image
         uses: docker/build-push-action@v3
+        if: github.event_name == 'pull_request'
         with:
-          context: centos/${{ matrix.centos_release }}
-          file: centos/${{ matrix.centos_release }}/Containerfile
+          context: ${{ env.distro }}/${{ matrix.release }}
+          file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}
+
+      - name: Build and push ${{ env.distro_pretty }} ${{ matrix.release }} toolbox image
+        uses: docker/build-push-action@v3
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main'
+        with:
+          context: ${{ env.distro }}/${{ matrix.release }}
+          file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: quay.io/toolbx-images/centos-toolbox:${{ matrix.centos_release }}
+          tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}
 
       - name: Push latest tag
-        if: env.latest_centos_release == matrix.centos_release
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main' && env.latest_release == matrix.release
         uses: docker/build-push-action@v3
         with:
-          context: centos/${{ matrix.centos_release }}
-          file: centos/${{ matrix.centos_release }}/Containerfile
+          context: ${{ env.distro }}/${{ matrix.release }}
+          file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: quay.io/toolbx-images/centos-toolbox:latest
+          tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:latest

--- a/.github/workflows/debian.yaml
+++ b/.github/workflows/debian.yaml
@@ -1,8 +1,17 @@
 name: Build Debian toolbx images
 
+permissions: read-all
+
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
+    paths:
+      - debian/**
+      - .github/workflows/debian.yaml
+  pull_request:
+    branches:
+      - main
     paths:
       - debian/**
       - .github/workflows/debian.yaml
@@ -13,13 +22,15 @@ on:
 concurrency: ${{ github.workflow }}
 
 env:
-  latest_debian_release: 'unstable'
+  distro: 'debian'
+  distro_pretty: 'Debian'
+  latest_release: 'unstable'
 
 jobs:
   build-and-push-images:
     strategy:
       matrix:
-        debian_release: ['10', '11', 'testing', 'unstable']
+        release: ['10', '11', 'testing', 'unstable']
 
     runs-on: ubuntu-latest
     steps:
@@ -34,26 +45,38 @@ jobs:
 
       - name: Login to Quay.io
         uses: docker/login-action@v2
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main'
         with:
           registry: quay.io
           username: 'toolbx-images+github'
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      - name: Build and push Debian ${{ matrix.debian_release }} toolbox image
+      - name: Build ${{ env.distro_pretty }} ${{ matrix.release }} toolbox image
         uses: docker/build-push-action@v3
+        if: github.event_name == 'pull_request'
         with:
-          context: debian/${{ matrix.debian_release }}
-          file: debian/${{ matrix.debian_release }}/Containerfile
+          context: ${{ env.distro }}/${{ matrix.release }}
+          file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}
+
+      - name: Build and push ${{ env.distro_pretty }} ${{ matrix.release }} toolbox image
+        uses: docker/build-push-action@v3
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main'
+        with:
+          context: ${{ env.distro }}/${{ matrix.release }}
+          file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: quay.io/toolbx-images/debian-toolbox:${{ matrix.debian_release }}
+          tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}
 
       - name: Push latest tag
-        if: env.latest_debian_release == matrix.debian_release
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main' && env.latest_release == matrix.release
         uses: docker/build-push-action@v3
         with:
-          context: debian/${{ matrix.debian_release }}
-          file: debian/${{ matrix.debian_release }}/Containerfile
+          context: ${{ env.distro }}/${{ matrix.release }}
+          file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: quay.io/toolbx-images/debian-toolbox:latest
+          tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:latest

--- a/.github/workflows/rhel.yaml
+++ b/.github/workflows/rhel.yaml
@@ -1,23 +1,36 @@
 name: Build RHEL toolbx images
 
+permissions: read-all
+
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
     paths:
       - rhel/**
       - .github/workflows/rhel.yaml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - rhel/**
+      - .github/workflows/rhel.yaml
+  schedule:
+    - cron:  '0 0 * * MON'
 
 # Prevent multiple workflow runs from racing
 concurrency: ${{ github.workflow }}
 
 env:
-  latest_rhel_release: '9.0'
+  distro: 'rhel'
+  distro_pretty: 'RHEL'
+  latest_release: '9.0'
 
 jobs:
   build-and-push-images:
     strategy:
       matrix:
-        rhel_release: ['8.2', '8.4', '8.6', '9.0']
+        release: ['8.2', '8.4', '8.6', '9.0']
 
     runs-on: ubuntu-latest
     steps:
@@ -32,26 +45,38 @@ jobs:
 
       - name: Login to Quay.io
         uses: docker/login-action@v2
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main'
         with:
           registry: quay.io
           username: 'toolbx-images+github'
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      - name: Build and push RHEL ${{ matrix.rhel_release }} toolbox image
+      - name: Build ${{ env.distro_pretty }} ${{ matrix.release }} toolbox image
         uses: docker/build-push-action@v3
+        if: github.event_name == 'pull_request'
         with:
-          context: rhel/${{ matrix.rhel_release }}
-          file: rhel/${{ matrix.rhel_release }}/Containerfile
+          context: ${{ env.distro }}/${{ matrix.release }}
+          file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}
+
+      - name: Build and push ${{ env.distro_pretty }} ${{ matrix.release }} toolbox image
+        uses: docker/build-push-action@v3
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main'
+        with:
+          context: ${{ env.distro }}/${{ matrix.release }}
+          file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: quay.io/toolbx-images/rhel-toolbox:${{ matrix.rhel_release }}
+          tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}
 
       - name: Push latest tag
-        if: env.latest_rhel_release == matrix.rhel_release
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main' && env.latest_release == matrix.release
         uses: docker/build-push-action@v3
         with:
-          context: rhel/${{ matrix.rhel_release }}
-          file: rhel/${{ matrix.rhel_release }}/Containerfile
+          context: ${{ env.distro }}/${{ matrix.release }}
+          file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: quay.io/toolbx-images/rhel-toolbox:latest
+          tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:latest

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -1,8 +1,17 @@
 name: Build Ubuntu toolbx images
 
+permissions: read-all
+
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
+    paths:
+      - ubuntu/**
+      - .github/workflows/ubuntu.yaml
+  pull_request:
+    branches:
+      - main
     paths:
       - ubuntu/**
       - .github/workflows/ubuntu.yaml
@@ -13,13 +22,15 @@ on:
 concurrency: ${{ github.workflow }}
 
 env:
-  latest_ubuntu_release: '22.04'
+  distro: 'ubuntu'
+  distro_pretty: 'Ubuntu'
+  latest_release: '22.04'
 
 jobs:
   build-and-push-images:
     strategy:
       matrix:
-        ubuntu_release: ['16.04', '18.04', '20.04', '22.04']
+        release: ['16.04', '18.04', '20.04', '22.04']
 
     runs-on: ubuntu-latest
     steps:
@@ -34,26 +45,38 @@ jobs:
 
       - name: Login to Quay.io
         uses: docker/login-action@v2
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main'
         with:
           registry: quay.io
           username: 'toolbx-images+github'
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      - name: Build and push Ubuntu ${{ matrix.ubuntu_release }} toolbox image
+      - name: Build ${{ env.distro_pretty }} ${{ matrix.release }} toolbox image
         uses: docker/build-push-action@v3
+        if: github.event_name == 'pull_request'
         with:
-          context: ubuntu/${{ matrix.ubuntu_release }}
-          file: ubuntu/${{ matrix.ubuntu_release }}/Containerfile
+          context: ${{ env.distro }}/${{ matrix.release }}
+          file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}
+
+      - name: Build and push ${{ env.distro_pretty }} ${{ matrix.release }} toolbox image
+        uses: docker/build-push-action@v3
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main'
+        with:
+          context: ${{ env.distro }}/${{ matrix.release }}
+          file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: quay.io/toolbx-images/ubuntu-toolbox:${{ matrix.ubuntu_release }}
+          tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}
 
       - name: Push latest tag
-        if: env.latest_ubuntu_release == matrix.ubuntu_release
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main' && env.latest_release == matrix.release
         uses: docker/build-push-action@v3
         with:
-          context: ubuntu/${{ matrix.ubuntu_release }}
-          file: ubuntu/${{ matrix.ubuntu_release }}/Containerfile
+          context: ${{ env.distro }}/${{ matrix.release }}
+          file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: quay.io/toolbx-images/ubuntu-toolbox:latest
+          tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:latest

--- a/README.md
+++ b/README.md
@@ -68,12 +68,6 @@ Container images to use with [toolbx] ([GitHub]).
   $ toolbox enter ubuntu-toolbox-16.04
   ```
 
-## Hacking on images
-
-As we have limited free GitHub Actions minutes, we do not trigger builds on
-PRs, only on merged commits. Please test you image builds locally before
-submitting a PR.
-
 [toolbx]: https://containertoolbx.org
 [GitHub]: https://github.com/containers/toolbox
 [Arch Linux]: https://hub.docker.com/_/archlinux/


### PR DESCRIPTION
Use shared names for environment variables to unify most of the workflow definition for all distributions.

Remove obsolete GitHub Action notes from README as we apparently have unlimited action minutes for free repositories.