### PR TITLE
workflows: Split PRs & push/schedule jobs

### DIFF
--- a/.github/workflows/archlinux-pr.yaml
+++ b/.github/workflows/archlinux-pr.yaml
@@ -1,19 +1,14 @@
-name: "Arch Linux: Build and push toolbx image"
+name: "Arch Linux: Build toolbx image for PRs"
 
 permissions: read-all
 
 on:
-  push:
+  pull_request:
     branches:
       - main
     paths:
       - archlinux/**
-      - .github/workflows/archlinux.yaml
-  schedule:
-    - cron:  '0 0 * * MON'
-
-# Prevent multiple workflow runs from racing
-concurrency: ${{ github.workflow }}
+      - .github/workflows/archlinux-pr.yaml
 
 env:
   distro: 'archlinux'
@@ -30,18 +25,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Login to Quay.io
-        uses: docker/login-action@v2
-        with:
-          registry: quay.io
-          username: 'toolbx-images+github'
-          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
-
-      - name: Build and push ${{ env.distro_pretty }} toolbx image
+      - name: Build ${{ env.distro_pretty }} ${{ matrix.release }} toolbox image
         uses: docker/build-push-action@v3
         with:
           context: ${{ env.distro }}
           file: ${{ env.distro }}/Containerfile
           platforms: linux/amd64
-          push: true
+          push: false
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:latest

--- a/.github/workflows/centos-pr.yaml
+++ b/.github/workflows/centos-pr.yaml
@@ -1,0 +1,42 @@
+name: "CentOS: Build toolbx images for PRs"
+
+permissions: read-all
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - centos/**
+      - .github/workflows/centos-pr.yaml
+
+env:
+  distro: 'centos'
+  distro_pretty: 'CentOS'
+  latest_release: 'stream9'
+
+jobs:
+  build-images:
+    strategy:
+      matrix:
+        release: ['stream8', 'stream9']
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build ${{ env.distro_pretty }} ${{ matrix.release }} toolbox image
+        uses: docker/build-push-action@v3
+        with:
+          context: ${{ env.distro }}/${{ matrix.release }}
+          file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}

--- a/.github/workflows/centos.yaml
+++ b/.github/workflows/centos.yaml
@@ -1,15 +1,9 @@
-name: Build CentOS Stream toolbx images
+name: "CentOS: Build and push toolbx images"
 
 permissions: read-all
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - centos/**
-      - .github/workflows/centos.yaml
-  pull_request:
     branches:
       - main
     paths:
@@ -45,25 +39,13 @@ jobs:
 
       - name: Login to Quay.io
         uses: docker/login-action@v2
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main'
         with:
           registry: quay.io
           username: 'toolbx-images+github'
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      - name: Build ${{ env.distro_pretty }} ${{ matrix.release }} toolbox image
-        uses: docker/build-push-action@v3
-        if: github.event_name == 'pull_request'
-        with:
-          context: ${{ env.distro }}/${{ matrix.release }}
-          file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
-          platforms: linux/amd64,linux/arm64
-          push: false
-          tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}
-
       - name: Build and push ${{ env.distro_pretty }} ${{ matrix.release }} toolbox image
         uses: docker/build-push-action@v3
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main'
         with:
           context: ${{ env.distro }}/${{ matrix.release }}
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
@@ -72,7 +54,7 @@ jobs:
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}
 
       - name: Push latest tag
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main' && env.latest_release == matrix.release
+        if: env.latest_release == matrix.release
         uses: docker/build-push-action@v3
         with:
           context: ${{ env.distro }}/${{ matrix.release }}

--- a/.github/workflows/debian-pr.yaml
+++ b/.github/workflows/debian-pr.yaml
@@ -1,0 +1,42 @@
+name: "Debian: Build toolbx images for PRs"
+
+permissions: read-all
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - debian/**
+      - .github/workflows/debian-pr.yaml
+
+env:
+  distro: 'debian'
+  distro_pretty: 'Debian'
+  latest_release: 'unstable'
+
+jobs:
+  build-images:
+    strategy:
+      matrix:
+        release: ['10', '11', 'testing', 'unstable']
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build ${{ env.distro_pretty }} ${{ matrix.release }} toolbox image
+        uses: docker/build-push-action@v3
+        with:
+          context: ${{ env.distro }}/${{ matrix.release }}
+          file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}

--- a/.github/workflows/debian.yaml
+++ b/.github/workflows/debian.yaml
@@ -1,15 +1,9 @@
-name: Build Debian toolbx images
+name: "Debian: Build and push toolbx images"
 
 permissions: read-all
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - debian/**
-      - .github/workflows/debian.yaml
-  pull_request:
     branches:
       - main
     paths:
@@ -45,25 +39,13 @@ jobs:
 
       - name: Login to Quay.io
         uses: docker/login-action@v2
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main'
         with:
           registry: quay.io
           username: 'toolbx-images+github'
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      - name: Build ${{ env.distro_pretty }} ${{ matrix.release }} toolbox image
-        uses: docker/build-push-action@v3
-        if: github.event_name == 'pull_request'
-        with:
-          context: ${{ env.distro }}/${{ matrix.release }}
-          file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
-          platforms: linux/amd64,linux/arm64
-          push: false
-          tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}
-
       - name: Build and push ${{ env.distro_pretty }} ${{ matrix.release }} toolbox image
         uses: docker/build-push-action@v3
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main'
         with:
           context: ${{ env.distro }}/${{ matrix.release }}
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
@@ -72,7 +54,7 @@ jobs:
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}
 
       - name: Push latest tag
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main' && env.latest_release == matrix.release
+        if: env.latest_release == matrix.release
         uses: docker/build-push-action@v3
         with:
           context: ${{ env.distro }}/${{ matrix.release }}

--- a/.github/workflows/rhel-pr.yaml
+++ b/.github/workflows/rhel-pr.yaml
@@ -1,0 +1,42 @@
+name: "RHEL: Build toolbx images for PRs"
+
+permissions: read-all
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - rhel/**
+      - .github/workflows/rhel-pr.yaml
+
+env:
+  distro: 'rhel'
+  distro_pretty: 'RHEL'
+  latest_release: '9.0'
+
+jobs:
+  build-images:
+    strategy:
+      matrix:
+        release: ['8.2', '8.4', '8.6', '9.0']
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build ${{ env.distro_pretty }} ${{ matrix.release }} toolbox image
+        uses: docker/build-push-action@v3
+        with:
+          context: ${{ env.distro }}/${{ matrix.release }}
+          file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}

--- a/.github/workflows/rhel.yaml
+++ b/.github/workflows/rhel.yaml
@@ -1,15 +1,9 @@
-name: Build RHEL toolbx images
+name: "RHEL: Build and push toolbx images"
 
 permissions: read-all
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - rhel/**
-      - .github/workflows/rhel.yaml
-  pull_request:
     branches:
       - main
     paths:
@@ -45,25 +39,13 @@ jobs:
 
       - name: Login to Quay.io
         uses: docker/login-action@v2
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main'
         with:
           registry: quay.io
           username: 'toolbx-images+github'
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      - name: Build ${{ env.distro_pretty }} ${{ matrix.release }} toolbox image
-        uses: docker/build-push-action@v3
-        if: github.event_name == 'pull_request'
-        with:
-          context: ${{ env.distro }}/${{ matrix.release }}
-          file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
-          platforms: linux/amd64,linux/arm64
-          push: false
-          tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}
-
       - name: Build and push ${{ env.distro_pretty }} ${{ matrix.release }} toolbox image
         uses: docker/build-push-action@v3
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main'
         with:
           context: ${{ env.distro }}/${{ matrix.release }}
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
@@ -72,7 +54,7 @@ jobs:
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}
 
       - name: Push latest tag
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main' && env.latest_release == matrix.release
+        if: env.latest_release == matrix.release
         uses: docker/build-push-action@v3
         with:
           context: ${{ env.distro }}/${{ matrix.release }}

--- a/.github/workflows/ubuntu-pr.yaml
+++ b/.github/workflows/ubuntu-pr.yaml
@@ -1,0 +1,42 @@
+name: "Ubuntu: Build toolbx images for PRs"
+
+permissions: read-all
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ubuntu/**
+      - .github/workflows/ubuntu-pr.yaml
+
+env:
+  distro: 'ubuntu'
+  distro_pretty: 'Ubuntu'
+  latest_release: '22.04'
+
+jobs:
+  build-images:
+    strategy:
+      matrix:
+        release: ['16.04', '18.04', '20.04', '22.04']
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build ${{ env.distro_pretty }} ${{ matrix.release }} toolbox image
+        uses: docker/build-push-action@v3
+        with:
+          context: ${{ env.distro }}/${{ matrix.release }}
+          file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -1,15 +1,9 @@
-name: Build Ubuntu toolbx images
+name: "Ubuntu: Build and push toolbx images"
 
 permissions: read-all
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - ubuntu/**
-      - .github/workflows/ubuntu.yaml
-  pull_request:
     branches:
       - main
     paths:
@@ -45,25 +39,13 @@ jobs:
 
       - name: Login to Quay.io
         uses: docker/login-action@v2
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main'
         with:
           registry: quay.io
           username: 'toolbx-images+github'
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      - name: Build ${{ env.distro_pretty }} ${{ matrix.release }} toolbox image
-        uses: docker/build-push-action@v3
-        if: github.event_name == 'pull_request'
-        with:
-          context: ${{ env.distro }}/${{ matrix.release }}
-          file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
-          platforms: linux/amd64,linux/arm64
-          push: false
-          tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}
-
       - name: Build and push ${{ env.distro_pretty }} ${{ matrix.release }} toolbox image
         uses: docker/build-push-action@v3
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main'
         with:
           context: ${{ env.distro }}/${{ matrix.release }}
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
@@ -72,7 +54,7 @@ jobs:
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}
 
       - name: Push latest tag
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref_name == 'refs/heads/main' && env.latest_release == matrix.release
+        if: env.latest_release == matrix.release
         uses: docker/build-push-action@v3
         with:
           context: ${{ env.distro }}/${{ matrix.release }}


### PR DESCRIPTION
This simplifies the logic and will enable concurent PR testing while keeping push & scheduled workflows running sequentially.