### PR TITLE
github/workflow: Do not use cache to always update

### DIFF
--- a/.github/workflows/archlinux-pr.yaml
+++ b/.github/workflows/archlinux-pr.yaml
@@ -32,4 +32,5 @@ jobs:
           file: ${{ env.distro }}/Containerfile
           platforms: linux/amd64
           push: false
+          no-cache: true
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:latest

--- a/.github/workflows/archlinux.yaml
+++ b/.github/workflows/archlinux.yaml
@@ -44,4 +44,5 @@ jobs:
           file: ${{ env.distro }}/Containerfile
           platforms: linux/amd64
           push: true
+          no-cache: true
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:latest

--- a/.github/workflows/centos-pr.yaml
+++ b/.github/workflows/centos-pr.yaml
@@ -39,4 +39,5 @@ jobs:
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: false
+          no-cache: true
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}

--- a/.github/workflows/centos.yaml
+++ b/.github/workflows/centos.yaml
@@ -61,4 +61,5 @@ jobs:
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          no-cache: true
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:latest

--- a/.github/workflows/debian-pr.yaml
+++ b/.github/workflows/debian-pr.yaml
@@ -39,4 +39,5 @@ jobs:
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: false
+          no-cache: true
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}

--- a/.github/workflows/debian.yaml
+++ b/.github/workflows/debian.yaml
@@ -61,4 +61,5 @@ jobs:
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          no-cache: true
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:latest

--- a/.github/workflows/rhel-pr.yaml
+++ b/.github/workflows/rhel-pr.yaml
@@ -39,4 +39,5 @@ jobs:
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: false
+          no-cache: true
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}

--- a/.github/workflows/rhel.yaml
+++ b/.github/workflows/rhel.yaml
@@ -61,4 +61,5 @@ jobs:
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          no-cache: true
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:latest

--- a/.github/workflows/ubuntu-pr.yaml
+++ b/.github/workflows/ubuntu-pr.yaml
@@ -39,4 +39,5 @@ jobs:
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: false
+          no-cache: true
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -61,4 +61,5 @@ jobs:
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          no-cache: true
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:latest


### PR DESCRIPTION
Make sure to not re-use cached layers to always fully update the image every time we rebuilt it.

See: https://github.com/toolbx-images/images/issues/5