### PR TITLE
centos: Temporarily remove gnupg2-smime

### DIFF
--- a/centos/stream8/extra-packages
+++ b/centos/stream8/extra-packages
@@ -7,7 +7,6 @@ findutils
 flatpak-spawn
 git
 gnupg
-gnupg2-smime
 gvfs-client
 hostname
 iproute

--- a/centos/stream9/extra-packages
+++ b/centos/stream9/extra-packages
@@ -7,7 +7,6 @@ findutils
 flatpak-spawn
 git
 gnupg
-gnupg2-smime
 gvfs-client
 hostname
 iproute


### PR DESCRIPTION
Currently causing dependency issue when enabling EPEL.