### PR TITLE
centos/stream9: Re-add gnupg2-smime

### DIFF
--- a/centos/stream9/extra-packages
+++ b/centos/stream9/extra-packages
@@ -7,6 +7,7 @@ findutils
 flatpak-spawn
 git
 gnupg
+gnupg2-smime
 gvfs-client
 hostname
 iproute


### PR DESCRIPTION
Partially revert "centos: Temporarily remove gnupg2-smime"

This partially reverts commit 685bb34b06328e832452ff8425cb514576ed95c4.