### PR TITLE
github/workflow: Use the cached image for pushing the latest tag

### DIFF
--- a/.github/workflows/centos.yaml
+++ b/.github/workflows/centos.yaml
@@ -51,6 +51,7 @@ jobs:
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          no-cache: true
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}
 
       - name: Push latest tag
@@ -61,5 +62,4 @@ jobs:
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          no-cache: true
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:latest

--- a/.github/workflows/debian.yaml
+++ b/.github/workflows/debian.yaml
@@ -51,6 +51,7 @@ jobs:
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          no-cache: true
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}
 
       - name: Push latest tag
@@ -61,5 +62,4 @@ jobs:
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          no-cache: true
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:latest

--- a/.github/workflows/opensuse.yaml
+++ b/.github/workflows/opensuse.yaml
@@ -51,6 +51,7 @@ jobs:
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          no-cache: true
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}
 
       - name: Push latest tag
@@ -61,5 +62,4 @@ jobs:
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          no-cache: true
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:latest

--- a/.github/workflows/rhel.yaml
+++ b/.github/workflows/rhel.yaml
@@ -51,6 +51,7 @@ jobs:
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          no-cache: true
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}
 
       - name: Push latest tag
@@ -61,5 +62,4 @@ jobs:
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          no-cache: true
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:latest

--- a/.github/workflows/rockylinux.yaml
+++ b/.github/workflows/rockylinux.yaml
@@ -51,6 +51,7 @@ jobs:
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          no-cache: true
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}
 
       - name: Push latest tag
@@ -61,5 +62,4 @@ jobs:
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          no-cache: true
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:latest

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -51,6 +51,7 @@ jobs:
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          no-cache: true
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:${{ matrix.release }}
 
       - name: Push latest tag
@@ -61,5 +62,4 @@ jobs:
           file: ${{ env.distro }}/${{ matrix.release }}/Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          no-cache: true
           tags: quay.io/toolbx-images/${{ env.distro }}-toolbox:latest


### PR DESCRIPTION
The workflows were wrongly using the 'no-cache' option only for the "latest" build and push action and were not correctly rebuilding everything.

Let's use this option for all builds while not using it in the latest tag push as we don't need to rebuild something we've just built.