### PR TITLE
Ubuntu: Added flatpak-xdg-utils to extra-packages and linked flatpak-spawn to /usr/bin

### DIFF
--- a/ubuntu/20.04/Containerfile
+++ b/ubuntu/20.04/Containerfile
@@ -37,3 +37,6 @@ RUN sed -i '/^auth.*pam_unix.so/s/nullok_secure/try_first_pass nullok/' /etc/pam
 
 # Fix empty bind-mount to clear selinuxfs (see #337)
 RUN mkdir /usr/share/empty
+
+# Add flatpak-spawn to /usr/bin
+RUN ln -s /usr/libexec/flatpak-xdg-utils/flatpak-spawn /usr/bin/

--- a/ubuntu/20.04/extra-packages
+++ b/ubuntu/20.04/extra-packages
@@ -6,3 +6,4 @@ unzip
 zip
 zsh
 curl
+flatpak-xdg-utils

--- a/ubuntu/22.04/Containerfile
+++ b/ubuntu/22.04/Containerfile
@@ -34,3 +34,6 @@ RUN rm /extra-packages
 
 # Fix empty bind-mount to clear selinuxfs (see #337)
 RUN mkdir /usr/share/empty
+
+# Add flatpak-spawn to /usr/bin
+RUN ln -s /usr/libexec/flatpak-xdg-utils/flatpak-spawn /usr/bin/

--- a/ubuntu/22.04/extra-packages
+++ b/ubuntu/22.04/extra-packages
@@ -6,3 +6,4 @@ unzip
 zip
 zsh
 curl
+flatpak-xdg-utils


### PR DESCRIPTION
This allows [toolbox-vscode](https://github.com/owtaylor/toolbox-vscode) to work with the Ubuntu Containers. The package was introduced in version 20.04, that's why there is no changes on 16.04 and 18.04.