### PR TITLE
alpine: Remove /media and let toolbox handle it

### DIFF
--- a/alpine/3.16/Containerfile
+++ b/alpine/3.16/Containerfile
@@ -20,5 +20,5 @@ RUN echo "%wheel ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/toolbox
 # Copy the os-release file
 RUN cp -p /etc/os-release /usr/lib/os-release
 
-# Ensure that /media is a symlink to /run/media
-RUN rm -rf /media && ln -snf /run/media /media
+# Clear out /media
+RUN rm -rf /media

--- a/alpine/3.17/Containerfile
+++ b/alpine/3.17/Containerfile
@@ -20,5 +20,5 @@ RUN echo "%wheel ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/toolbox
 # Copy the os-release file
 RUN cp -p /etc/os-release /usr/lib/os-release
 
-# Ensure that /media is a symlink to /run/media
-RUN rm -rf /media && ln -snf /run/media /media
+# Clear out /media
+RUN rm -rf /media


### PR DESCRIPTION
/media has a different meaning / setup depending of the distribution. Remove it and toolbox will re-create as neeed to match the host distribution setup.

Fixes: https://github.com/toolbx-images/images/issues/65