### PR TITLE
Contribute back changes from Apertis images

### DIFF
--- a/debian/10/Containerfile
+++ b/debian/10/Containerfile
@@ -17,6 +17,9 @@ RUN rm /etc/apt/apt.conf.d/docker-gzip-indexes /etc/apt/apt.conf.d/docker-no-lan
 # adds it too late in the order) skips this step
 RUN sed -Ei 's/^(hosts:.*)(\<files\>)\s*(.*)/\1\2 myhostname \3/' /etc/nsswitch.conf
 
+# Prevent questions when installing packages
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Install extra packages as well as libnss-myhostname
 COPY extra-packages /
 RUN apt-get update && \

--- a/debian/10/Containerfile
+++ b/debian/10/Containerfile
@@ -20,6 +20,9 @@ RUN sed -Ei 's/^(hosts:.*)(\<files\>)\s*(.*)/\1\2 myhostname \3/' /etc/nsswitch.
 # Prevent questions when installing packages
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Make flatpak-xdg-utils usable inside the toolbox
+COPY toolbox-flatpak-xdg-utils.sh /etc/profile.d
+
 # Install extra packages as well as libnss-myhostname
 COPY extra-packages /
 RUN apt-get update && \

--- a/debian/10/toolbox-flatpak-xdg-utils.sh
+++ b/debian/10/toolbox-flatpak-xdg-utils.sh
@@ -1,0 +1,12 @@
+# shellcheck shell=sh disable=SC2153
+# Add flatpak-xdg-utils to PATH to allow running nested toolbox
+# containers (i.e. uses flatpak-spawn).
+# This also makes the xdg-utils replacements available as part of
+# flatpak-xdg-utils (e.g. xdg-open) usable inside toolbox (requires
+# xdg-desktop-portal on the host side).
+
+if [ -f /run/.containerenv ] && [ -f /run/.toolboxenv ]
+then
+   PATH="/usr/libexec/flatpak-xdg-utils:$PATH"
+   export PATH
+fi

--- a/debian/11/Containerfile
+++ b/debian/11/Containerfile
@@ -17,6 +17,9 @@ RUN rm /etc/apt/apt.conf.d/docker-gzip-indexes /etc/apt/apt.conf.d/docker-no-lan
 # adds it too late in the order) skips this step
 RUN sed -Ei 's/^(hosts:.*)(\<files\>)\s*(.*)/\1\2 myhostname \3/' /etc/nsswitch.conf
 
+# Prevent questions when installing packages
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Install extra packages as well as libnss-myhostname
 COPY extra-packages /
 RUN apt-get update && \

--- a/debian/11/Containerfile
+++ b/debian/11/Containerfile
@@ -20,6 +20,9 @@ RUN sed -Ei 's/^(hosts:.*)(\<files\>)\s*(.*)/\1\2 myhostname \3/' /etc/nsswitch.
 # Prevent questions when installing packages
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Make flatpak-xdg-utils usable inside the toolbox
+COPY toolbox-flatpak-xdg-utils.sh /etc/profile.d
+
 # Install extra packages as well as libnss-myhostname
 COPY extra-packages /
 RUN apt-get update && \

--- a/debian/11/toolbox-flatpak-xdg-utils.sh
+++ b/debian/11/toolbox-flatpak-xdg-utils.sh
@@ -1,0 +1,12 @@
+# shellcheck shell=sh disable=SC2153
+# Add flatpak-xdg-utils to PATH to allow running nested toolbox
+# containers (i.e. uses flatpak-spawn).
+# This also makes the xdg-utils replacements available as part of
+# flatpak-xdg-utils (e.g. xdg-open) usable inside toolbox (requires
+# xdg-desktop-portal on the host side).
+
+if [ -f /run/.containerenv ] && [ -f /run/.toolboxenv ]
+then
+   PATH="/usr/libexec/flatpak-xdg-utils:$PATH"
+   export PATH
+fi

--- a/debian/testing/Containerfile
+++ b/debian/testing/Containerfile
@@ -17,6 +17,9 @@ RUN rm /etc/apt/apt.conf.d/docker-gzip-indexes /etc/apt/apt.conf.d/docker-no-lan
 # adds it too late in the order) skips this step
 RUN sed -Ei 's/^(hosts:.*)(\<files\>)\s*(.*)/\1\2 myhostname \3/' /etc/nsswitch.conf
 
+# Prevent questions when installing packages
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Install extra packages as well as libnss-myhostname
 COPY extra-packages /
 RUN apt-get update && \

--- a/debian/testing/Containerfile
+++ b/debian/testing/Containerfile
@@ -20,6 +20,9 @@ RUN sed -Ei 's/^(hosts:.*)(\<files\>)\s*(.*)/\1\2 myhostname \3/' /etc/nsswitch.
 # Prevent questions when installing packages
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Make flatpak-xdg-utils usable inside the toolbox
+COPY toolbox-flatpak-xdg-utils.sh /etc/profile.d
+
 # Install extra packages as well as libnss-myhostname
 COPY extra-packages /
 RUN apt-get update && \

--- a/debian/testing/toolbox-flatpak-xdg-utils.sh
+++ b/debian/testing/toolbox-flatpak-xdg-utils.sh
@@ -1,0 +1,12 @@
+# shellcheck shell=sh disable=SC2153
+# Add flatpak-xdg-utils to PATH to allow running nested toolbox
+# containers (i.e. uses flatpak-spawn).
+# This also makes the xdg-utils replacements available as part of
+# flatpak-xdg-utils (e.g. xdg-open) usable inside toolbox (requires
+# xdg-desktop-portal on the host side).
+
+if [ -f /run/.containerenv ] && [ -f /run/.toolboxenv ]
+then
+   PATH="/usr/libexec/flatpak-xdg-utils:$PATH"
+   export PATH
+fi

--- a/debian/unstable/Containerfile
+++ b/debian/unstable/Containerfile
@@ -17,6 +17,9 @@ RUN rm /etc/apt/apt.conf.d/docker-gzip-indexes /etc/apt/apt.conf.d/docker-no-lan
 # adds it too late in the order) skips this step
 RUN sed -Ei 's/^(hosts:.*)(\<files\>)\s*(.*)/\1\2 myhostname \3/' /etc/nsswitch.conf
 
+# Prevent questions when installing packages
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Install extra packages as well as libnss-myhostname
 COPY extra-packages /
 RUN apt-get update && \

--- a/debian/unstable/Containerfile
+++ b/debian/unstable/Containerfile
@@ -20,6 +20,9 @@ RUN sed -Ei 's/^(hosts:.*)(\<files\>)\s*(.*)/\1\2 myhostname \3/' /etc/nsswitch.
 # Prevent questions when installing packages
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Make flatpak-xdg-utils usable inside the toolbox
+COPY toolbox-flatpak-xdg-utils.sh /etc/profile.d
+
 # Install extra packages as well as libnss-myhostname
 COPY extra-packages /
 RUN apt-get update && \

--- a/debian/unstable/toolbox-flatpak-xdg-utils.sh
+++ b/debian/unstable/toolbox-flatpak-xdg-utils.sh
@@ -1,0 +1,12 @@
+# shellcheck shell=sh disable=SC2153
+# Add flatpak-xdg-utils to PATH to allow running nested toolbox
+# containers (i.e. uses flatpak-spawn).
+# This also makes the xdg-utils replacements available as part of
+# flatpak-xdg-utils (e.g. xdg-open) usable inside toolbox (requires
+# xdg-desktop-portal on the host side).
+
+if [ -f /run/.containerenv ] && [ -f /run/.toolboxenv ]
+then
+   PATH="/usr/libexec/flatpak-xdg-utils:$PATH"
+   export PATH
+fi


### PR DESCRIPTION
* Prevent questions when installing packages during the build
* Make flatpak-xdg-utils usable inside the toolbox