### PR TITLE
Fix Ubuntu 18.04 missing core desktop metapackages

### DIFF
--- a/ubuntu/16.04/extra-packages
+++ b/ubuntu/16.04/extra-packages
@@ -2,7 +2,6 @@ curl
 git
 gnupg2
 keyutils
-libcap2-bin
 tree
 unzip
 zip

--- a/ubuntu/18.04/Containerfile
+++ b/ubuntu/18.04/Containerfile
@@ -17,13 +17,14 @@ RUN rm /etc/apt/apt.conf.d/docker-gzip-indexes /etc/apt/apt.conf.d/docker-no-lan
 # adds it too late in the order) skips this step
 RUN sed -Ei 's/^(hosts:.*)(\<files\>)\s*(.*)/\1\2 myhostname \3/' /etc/nsswitch.conf
 
-# FIXME: Restore documentation but do not upgrade all packages
+# Restore documentation but do not upgrade all packages
 # Install extra packages as well as libnss-myhostname
-# FIXME: Install ubuntu-minimal & ubuntu-standard
 COPY extra-packages /
 RUN sed -Ei '/apt-get (update|upgrade)/s/^/#/' /usr/local/sbin/unminimize && \
     apt-get update && \
+    yes | /usr/local/sbin/unminimize && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \
+        ubuntu-minimal ubuntu-standard \
         libnss-myhostname \
         $(cat extra-packages | xargs) && \
     rm -rd /var/lib/apt/lists/*

--- a/ubuntu/18.04/extra-packages
+++ b/ubuntu/18.04/extra-packages
@@ -2,7 +2,6 @@ curl
 git
 gnupg2
 keyutils
-libcap2-bin
 tree
 unzip
 zip

--- a/ubuntu/20.04/extra-packages
+++ b/ubuntu/20.04/extra-packages
@@ -3,7 +3,6 @@ flatpak-xdg-utils
 git
 gnupg2
 keyutils
-libcap2-bin
 tree
 unzip
 zip

--- a/ubuntu/22.04/extra-packages
+++ b/ubuntu/22.04/extra-packages
@@ -3,7 +3,6 @@ flatpak-xdg-utils
 git
 gnupg2
 keyutils
-libcap2-bin
 tree
 unzip
 zip

--- a/ubuntu/22.10/extra-packages
+++ b/ubuntu/22.10/extra-packages
@@ -3,7 +3,6 @@ flatpak-xdg-utils
 git
 gnupg2
 keyutils
-libcap2-bin
 tree
 unzip
 zip


### PR DESCRIPTION
It appears they were removed for some reason.
Bring them back as well as execution of `unminimize`.
It is now again aligned with other ubuntu releases.

Also, revert adding `libcap2-bin` to the package list.

Fixes: #72, #73