### PR TITLE
tweak archlinux/Containerfile to edit nsswitch.conf

### DIFF
--- a/archlinux/Containerfile
+++ b/archlinux/Containerfile
@@ -7,6 +7,12 @@ LABEL com.github.containers.toolbox="true" \
       summary="Base image for creating Arch Linux toolbox containers" \
       maintainer="Morten Linderud <foxboron@archlinux.org>"
 
+# Enable myhostname nss plugin for clean hostname resolution without patching
+# hosts (at least for sudo), add it right after 'mymachines' entry.
+RUN sed -Ei 's/^(hosts:.*)(\<mymachines\>)\s*(.*)/\1\2 myhostname \3/' /etc/nsswitch.conf
+# .. remove repeated 'myhostname' from the hosts line
+RUN sed -Ei 's/^(.*?myhostname.*)?\s+myhostname\s+(.*)/\1 \2/' /etc/nsswitch.conf
+
 # Install extra packages
 COPY extra-packages /
 RUN pacman -Syu --needed --noconfirm - < extra-packages


### PR DESCRIPTION
I ran into an issue using this image and distrobox. When I created a new container it could not reference itself by its hostname. 

```sh
$ hostname
terra
$ distrobox create archymcarch --image quay.io/toolbx-images/archlinux-toolbox
$ distrobox enter archymcarch
$ sudo pacman -S inetutils
$ hostname
archymcarch.terra
$ ping archymcarch.terra
ping: archymcarch.terra: Name or service not known
```

I found that if I moved `myhostname` directive it could do so. This PR tweaks the nsswitch.conf file so that myhostname is further to the start of the hosts: line