### PR TITLE
workflows: update ubuntu repositories beforehand (all)

### DIFF
--- a/.github/workflows/almalinux.yaml
+++ b/.github/workflows/almalinux.yaml
@@ -46,6 +46,7 @@ jobs:
       - name: Set up QEMU for multi-arch builds
         shell: bash
         run: |
+          sudo apt update
           sudo apt install qemu-user-static
 
       - name: Build container image

--- a/.github/workflows/alpine.yaml
+++ b/.github/workflows/alpine.yaml
@@ -46,6 +46,7 @@ jobs:
       - name: Set up QEMU for multi-arch builds
         shell: bash
         run: |
+          sudo apt update
           sudo apt install qemu-user-static
 
       - name: Build container image

--- a/.github/workflows/amazonlinux.yaml
+++ b/.github/workflows/amazonlinux.yaml
@@ -46,6 +46,7 @@ jobs:
       - name: Set up QEMU for multi-arch builds
         shell: bash
         run: |
+          sudo apt update
           sudo apt install qemu-user-static
 
       - name: Build container image

--- a/.github/workflows/archlinux.yaml
+++ b/.github/workflows/archlinux.yaml
@@ -46,6 +46,7 @@ jobs:
       # - name: Set up QEMU for multi-arch builds
       #   shell: bash
       #   run: |
+      #     sudo apt update
       #     sudo apt install qemu-user-static
 
       # - name: Build container image

--- a/.github/workflows/centos.yaml
+++ b/.github/workflows/centos.yaml
@@ -46,6 +46,7 @@ jobs:
       - name: Set up QEMU for multi-arch builds
         shell: bash
         run: |
+          sudo apt update
           sudo apt install qemu-user-static
 
       - name: Build container image

--- a/.github/workflows/debian.yaml
+++ b/.github/workflows/debian.yaml
@@ -46,6 +46,7 @@ jobs:
       - name: Set up QEMU for multi-arch builds
         shell: bash
         run: |
+          sudo apt update
           sudo apt install qemu-user-static
 
       - name: Build container image

--- a/.github/workflows/fedora.yaml
+++ b/.github/workflows/fedora.yaml
@@ -46,6 +46,7 @@ jobs:
       - name: Set up QEMU for multi-arch builds
         shell: bash
         run: |
+          sudo apt update
           sudo apt install qemu-user-static
 
       - name: Build container image

--- a/.github/workflows/opensuse.yaml
+++ b/.github/workflows/opensuse.yaml
@@ -46,6 +46,7 @@ jobs:
       - name: Set up QEMU for multi-arch builds
         shell: bash
         run: |
+          sudo apt update
           sudo apt install qemu-user-static
 
       - name: Build container image

--- a/.github/workflows/rhel.yaml
+++ b/.github/workflows/rhel.yaml
@@ -46,6 +46,7 @@ jobs:
       - name: Set up QEMU for multi-arch builds
         shell: bash
         run: |
+          sudo apt update
           sudo apt install qemu-user-static
 
       - name: Build container image

--- a/.github/workflows/rockylinux.yaml
+++ b/.github/workflows/rockylinux.yaml
@@ -46,6 +46,7 @@ jobs:
       - name: Set up QEMU for multi-arch builds
         shell: bash
         run: |
+          sudo apt update
           sudo apt install qemu-user-static
 
       - name: Build container image

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -46,6 +46,7 @@ jobs:
       - name: Set up QEMU for multi-arch builds
         shell: bash
         run: |
+          sudo apt update
           sudo apt install qemu-user-static
 
       - name: Build container image


### PR DESCRIPTION
We should update the ubuntu repos before installing `qemu-user-static` otherwise we can sometimes be hit with 404 errors.