### PR TITLE
opensuse/tumbleweed: Install xargs first

### DIFF
--- a/opensuse/tumbleweed/Containerfile
+++ b/opensuse/tumbleweed/Containerfile
@@ -10,6 +10,7 @@ LABEL com.github.containers.toolbox="true" \
 # Update packages, install extra packages and clean up cache 
 COPY extra-packages /
 RUN zypper update -y && \
+    zypper install -y findutils && \
     cat /extra-packages | xargs zypper install -y && \
     zypper clean
 RUN rm /extra-packages


### PR DESCRIPTION
It looks like xargs has been removed from the base image of tumbleweed. Let's make sure it's installed before using it.