### PR TITLE
github/workflows/centos: Also push zstd:chunked compressed images

### DIFF
--- a/.github/workflows/almalinux.yaml
+++ b/.github/workflows/almalinux.yaml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         release: ['8', '9']
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/alpine.yaml
+++ b/.github/workflows/alpine.yaml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         release: ['3.16', '3.17', '3.18', '3.19', '3.20', 'edge']
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/amazonlinux.yaml
+++ b/.github/workflows/amazonlinux.yaml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         release: ['2', '2023']
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/centos.yaml
+++ b/.github/workflows/centos.yaml
@@ -36,7 +36,7 @@ jobs:
   build-push-images:
     strategy:
       matrix:
-        release: ['stream8', 'stream9', 'stream10-development']
+        release: ['stream9', 'stream10-development']
 
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/centos.yaml
+++ b/.github/workflows/centos.yaml
@@ -84,6 +84,20 @@ jobs:
           registry: ${{ env.registry }}
           tags: ${{ matrix.release }}
 
+      - name: Push to Container Registry (zstd)
+        uses: redhat-actions/push-to-registry@v2
+        id: push-zstd
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release != matrix.release
+        with:
+          username: ${{ secrets.BOT_USERNAME }}
+          password: ${{ secrets.BOT_SECRET }}
+          image: ${{ env.distro }}-toolbox
+          registry: ${{ env.registry }}
+          tags: ${{ matrix.release }}-zstd
+          extra-args: |
+            --compression-format=zstd:chunked
+            --compression-level=19
+
       - name: Push to Container Registry (latest tag)
         uses: redhat-actions/push-to-registry@v2
         id: push-latest
@@ -94,6 +108,20 @@ jobs:
           image: ${{ env.distro }}-toolbox
           registry: ${{ env.registry }}
           tags: ${{ matrix.release }} latest
+
+      - name: Push to Container Registry (latest tag, zstd)
+        uses: redhat-actions/push-to-registry@v2
+        id: push-latest-zstd
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release == matrix.release
+        with:
+          username: ${{ secrets.BOT_USERNAME }}
+          password: ${{ secrets.BOT_SECRET }}
+          image: ${{ env.distro }}-toolbox
+          registry: ${{ env.registry }}
+          tags: ${{ matrix.release }}-zstd latest-zstd
+          extra-args: |
+            --compression-format=zstd:chunked
+            --compression-level=19
 
       - name: Login to Container Registry
         uses: redhat-actions/podman-login@v1
@@ -114,10 +142,26 @@ jobs:
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
 
+      - name: Sign container image (zstd)
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release != matrix.release
+        run: |
+          cosign sign -y --recursive --key env://COSIGN_PRIVATE_KEY ${{ env.registry }}/${{ env.distro }}-toolbox@${{ steps.push-zstd.outputs.digest }}
+        env:
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+
       - name: Sign container image (latest)
         if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release == matrix.release
         run: |
           cosign sign -y --recursive --key env://COSIGN_PRIVATE_KEY ${{ env.registry }}/${{ env.distro }}-toolbox@${{ steps.push-latest.outputs.digest }}
+        env:
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+
+      - name: Sign container image (latest, zstd)
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release == matrix.release
+        run: |
+          cosign sign -y --recursive --key env://COSIGN_PRIVATE_KEY ${{ env.registry }}/${{ env.distro }}-toolbox@${{ steps.push-latest-zstd.outputs.digest }}
         env:
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}

--- a/.github/workflows/centos.yaml
+++ b/.github/workflows/centos.yaml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         release: ['stream8', 'stream9', 'stream10-development']
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/debian.yaml
+++ b/.github/workflows/debian.yaml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         release: ['10', '11', '12', 'testing', 'unstable']
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/debian.yaml
+++ b/.github/workflows/debian.yaml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         release: ['10', '11', '12', 'testing', 'unstable']
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/opensuse.yaml
+++ b/.github/workflows/opensuse.yaml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         release: ['tumbleweed']
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/rockylinux.yaml
+++ b/.github/workflows/rockylinux.yaml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         release: ['8', '9']
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/wolfi.yaml
+++ b/.github/workflows/wolfi.yaml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         release: ['latest']
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
github/workflows: Use Ubuntu 24.04 runners

---

github/workflows/centos: Also push zstd:chunked compressed images

See: https://github.com/toolbx-images/images/issues/128
See: https://fedoraproject.org/wiki/Changes/zstd:chunked
See: https://docs.podman.io/en/latest/markdown/podman-push.1.html#compression-format-gzip-zstd-zstd-chunked
See: https://github.com/coreos/fedora-coreos-tracker/issues/1660