### PR TITLE
centos: Enable EPEL for Stream 10

### DIFF
--- a/centos/stream10/Containerfile
+++ b/centos/stream10/Containerfile
@@ -19,6 +19,7 @@ RUN dnf -y upgrade && \
     dnf -y reinstall $(<missing-docs) && \
     dnf -y install 'dnf-command(config-manager)' && \
     dnf config-manager --set-enabled crb && \
+    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm && \
     dnf -y install $(<extra-packages) && \
     dnf clean all
 

--- a/centos/stream9/Containerfile
+++ b/centos/stream9/Containerfile
@@ -19,7 +19,7 @@ RUN dnf -y upgrade && \
     dnf -y reinstall $(<missing-docs) && \
     dnf -y install 'dnf-command(config-manager)' && \
     dnf config-manager --set-enabled crb && \
-    dnf -y install epel-release epel-next-release && \
+    dnf -y install https://dl.fedoraproject.org/pub/epel/epel{,-next}-release-latest-9.noarch.rpm && \
     dnf -y install $(<extra-packages) && \
     dnf clean all
 


### PR DESCRIPTION
centos: Enable EPEL for Stream 10

---

centos: Use recommended package for EPEL 9

See: https://docs.fedoraproject.org/en-US/epel/getting-started/#_el9