### PR TITLE
github/workflows: Keep Debian builds on ubuntu-22.04

### DIFF
--- a/.github/workflows/debian.yaml
+++ b/.github/workflows/debian.yaml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         release: ['10', '11', '12', 'testing', 'unstable']
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Debian container image builds are currently failing on Ubuntu 24.04 runners for Debian < 12.