### PR TITLE
github/workflows: Disable fail-fast

### DIFF
--- a/.github/workflows/almalinux.yaml
+++ b/.github/workflows/almalinux.yaml
@@ -35,6 +35,7 @@ concurrency:
 jobs:
   build-push-images:
     strategy:
+      fail-fast: false
       matrix:
         release: ['8', '9']
 

--- a/.github/workflows/alpine.yaml
+++ b/.github/workflows/alpine.yaml
@@ -35,6 +35,7 @@ concurrency:
 jobs:
   build-push-images:
     strategy:
+      fail-fast: false
       matrix:
         release: ['3.18', '3.19', '3.20', '3.21', 'edge']
 

--- a/.github/workflows/amazonlinux.yaml
+++ b/.github/workflows/amazonlinux.yaml
@@ -35,6 +35,7 @@ concurrency:
 jobs:
   build-push-images:
     strategy:
+      fail-fast: false
       matrix:
         release: ['2', '2023']
 

--- a/.github/workflows/centos.yaml
+++ b/.github/workflows/centos.yaml
@@ -35,6 +35,7 @@ concurrency:
 jobs:
   build-push-images:
     strategy:
+      fail-fast: false
       matrix:
         release: ['stream9', 'stream10']
 

--- a/.github/workflows/debian.yaml
+++ b/.github/workflows/debian.yaml
@@ -35,6 +35,7 @@ concurrency:
 jobs:
   build-push-images:
     strategy:
+      fail-fast: false
       matrix:
         release: ['10', '11', '12', 'testing', 'unstable']
 

--- a/.github/workflows/rockylinux.yaml
+++ b/.github/workflows/rockylinux.yaml
@@ -35,6 +35,7 @@ concurrency:
 jobs:
   build-push-images:
     strategy:
+      fail-fast: false
       matrix:
         release: ['8', '9']
 


### PR DESCRIPTION
Do not fail all builds if one version fails. This should keep images updated until the one with the failure is fixed.

See: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast