### PR TITLE
Unify workflows and version images with timestamp

### DIFF
--- a/.github/workflows/almalinux.yaml
+++ b/.github/workflows/almalinux.yaml
@@ -9,21 +9,16 @@ on:
     paths:
       - almalinux/**
       - .github/workflows/almalinux.yaml
+      - .github/workflows/build-push-images.yaml
   push:
     branches:
       - main
     paths:
       - almalinux/**
       - .github/workflows/almalinux.yaml
+      - .github/workflows/build-push-images.yaml
   schedule:
     - cron:  '0 0 * * MON'
-
-env:
-  distro: 'almalinux'
-  distro_pretty: 'AlmaLinux'
-  latest_release: '10'
-  platforms: 'linux/amd64, linux/arm64'
-  registry: 'quay.io/toolbx-images'
 
 # Prevent multiple workflow runs from racing to ensure that pushes are made
 # sequentially for the main branch. Also cancel in progress workflow runs for
@@ -34,91 +29,14 @@ concurrency:
 
 jobs:
   build-push-images:
-    strategy:
-      fail-fast: false
-      matrix:
-        release: ['8', '9', '10']
-
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU for multi-arch builds
-        shell: bash
-        run: |
-          sudo apt update
-          sudo apt install qemu-user-static
-
-      - name: Build container image
-        uses: redhat-actions/buildah-build@v2
-        if: env.latest_release != matrix.release
-        with:
-          platforms: ${{ env.platforms }}
-          context: ${{ env.distro }}/${{ matrix.release }}
-          image: ${{ env.distro }}-toolbox
-          tags: ${{ matrix.release }}
-          containerfiles: ${{ env.distro }}/${{ matrix.release }}/Containerfile
-          layers: false
-          oci: true
-
-      - name: Build container image (latest tag)
-        uses: redhat-actions/buildah-build@v2
-        if: env.latest_release == matrix.release
-        with:
-          platforms: ${{ env.platforms }}
-          context: ${{ env.distro }}/${{ matrix.release }}
-          image: ${{ env.distro }}-toolbox
-          tags: ${{ matrix.release }} latest
-          containerfiles: ${{ env.distro }}/${{ matrix.release }}/Containerfile
-          layers: false
-          oci: true
-
-      - name: Push to Container Registry
-        uses: redhat-actions/push-to-registry@v2
-        id: push
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release != matrix.release
-        with:
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-          image: ${{ env.distro }}-toolbox
-          registry: ${{ env.registry }}
-          tags: ${{ matrix.release }}
-
-      - name: Push to Container Registry (latest tag)
-        uses: redhat-actions/push-to-registry@v2
-        id: push-latest
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release == matrix.release
-        with:
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-          image: ${{ env.distro }}-toolbox
-          registry: ${{ env.registry }}
-          tags: ${{ matrix.release }} latest
-
-      - name: Login to Container Registry
-        uses: redhat-actions/podman-login@v1
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
-        with:
-          registry: ${{ env.registry }}
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-
-      - uses: sigstore/cosign-installer@v3.3.0
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
-
-      - name: Sign container image
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release != matrix.release
-        run: |
-          cosign sign -y --recursive --key env://COSIGN_PRIVATE_KEY ${{ env.registry }}/${{ env.distro }}-toolbox@${{ steps.push.outputs.digest }}
-        env:
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
-
-      - name: Sign container image (latest)
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release == matrix.release
-        run: |
-          cosign sign -y --recursive --key env://COSIGN_PRIVATE_KEY ${{ env.registry }}/${{ env.distro }}-toolbox@${{ steps.push-latest.outputs.digest }}
-        env:
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+    uses: ./.github/workflows/build-push-images.yaml
+    with:
+      distro: almalinux
+      releases: 8 9 10
+      latest-release: 10
+      registry: quay.io/toolbx-images
+      platforms: linux/amd64, linux/arm64
+    secrets:
+      registry-user: ${{ secrets.BOT_USERNAME }}
+      registry-password: ${{ secrets.BOT_PASSWORD }}
+      cosign-private-key: ${{ secrets.COSIGN_PRIVATE_KEY }}

--- a/.github/workflows/alpine.yaml
+++ b/.github/workflows/alpine.yaml
@@ -9,21 +9,16 @@ on:
     paths:
       - alpine/**
       - .github/workflows/alpine.yaml
+      - .github/workflows/build-push-images.yaml
   push:
     branches:
       - main
     paths:
       - alpine/**
       - .github/workflows/alpine.yaml
+      - .github/workflows/build-push-images.yaml
   schedule:
     - cron:  '0 0 * * MON'
-
-env:
-  distro: 'alpine'
-  distro_pretty: 'Alpine Linux'
-  latest_release: '3.21'
-  platforms: 'linux/amd64, linux/arm64'
-  registry: 'quay.io/toolbx-images'
 
 # Prevent multiple workflow runs from racing to ensure that pushes are made
 # sequentially for the main branch. Also cancel in progress workflow runs for
@@ -34,91 +29,15 @@ concurrency:
 
 jobs:
   build-push-images:
-    strategy:
-      fail-fast: false
-      matrix:
-        release: ['3.18', '3.19', '3.20', '3.21', 'edge']
+    uses: ./.github/workflows/build-push-images.yaml
+    with:
+      distro: alpine
+      releases: 3.18 3.19 3.20 3.21 edge
+      latest-release: 3.21
+      registry: quay.io/toolbx-images
+      platforms: linux/amd64, linux/arm64
+    secrets:
+      registry-user: ${{ secrets.BOT_USERNAME }}
+      registry-password: ${{ secrets.BOT_PASSWORD }}
+      cosign-private-key: ${{ secrets.COSIGN_PRIVATE_KEY }}
 
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU for multi-arch builds
-        shell: bash
-        run: |
-          sudo apt update
-          sudo apt install qemu-user-static
-
-      - name: Build container image
-        uses: redhat-actions/buildah-build@v2
-        if: env.latest_release != matrix.release
-        with:
-          platforms: ${{ env.platforms }}
-          context: ${{ env.distro }}/${{ matrix.release }}
-          image: ${{ env.distro }}-toolbox
-          tags: ${{ matrix.release }}
-          containerfiles: ${{ env.distro }}/${{ matrix.release }}/Containerfile
-          layers: false
-          oci: true
-
-      - name: Build container image (latest tag)
-        uses: redhat-actions/buildah-build@v2
-        if: env.latest_release == matrix.release
-        with:
-          platforms: ${{ env.platforms }}
-          context: ${{ env.distro }}/${{ matrix.release }}
-          image: ${{ env.distro }}-toolbox
-          tags: ${{ matrix.release }} latest
-          containerfiles: ${{ env.distro }}/${{ matrix.release }}/Containerfile
-          layers: false
-          oci: true
-
-      - name: Push to Container Registry
-        uses: redhat-actions/push-to-registry@v2
-        id: push
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release != matrix.release
-        with:
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-          image: ${{ env.distro }}-toolbox
-          registry: ${{ env.registry }}
-          tags: ${{ matrix.release }}
-
-      - name: Push to Container Registry (latest tag)
-        uses: redhat-actions/push-to-registry@v2
-        id: push-latest
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release == matrix.release
-        with:
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-          image: ${{ env.distro }}-toolbox
-          registry: ${{ env.registry }}
-          tags: ${{ matrix.release }} latest
-
-      - name: Login to Container Registry
-        uses: redhat-actions/podman-login@v1
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
-        with:
-          registry: ${{ env.registry }}
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-
-      - uses: sigstore/cosign-installer@v3.3.0
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
-
-      - name: Sign container image
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release != matrix.release
-        run: |
-          cosign sign -y --recursive --key env://COSIGN_PRIVATE_KEY ${{ env.registry }}/${{ env.distro }}-toolbox@${{ steps.push.outputs.digest }}
-        env:
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
-
-      - name: Sign container image (latest)
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release == matrix.release
-        run: |
-          cosign sign -y --recursive --key env://COSIGN_PRIVATE_KEY ${{ env.registry }}/${{ env.distro }}-toolbox@${{ steps.push-latest.outputs.digest }}
-        env:
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}

--- a/.github/workflows/amazonlinux.yaml
+++ b/.github/workflows/amazonlinux.yaml
@@ -9,21 +9,16 @@ on:
     paths:
       - amazonlinux/**
       - .github/workflows/amazonlinux.yaml
+      - .github/workflows/build-push-images.yaml
   push:
     branches:
       - main
     paths:
       - amazonlinux/**
       - .github/workflows/amazonlinux.yaml
+      - .github/workflows/build-push-images.yaml
   schedule:
     - cron:  '0 0 * * MON'
-
-env:
-  distro: 'amazonlinux'
-  distro_pretty: 'Amazon Linux'
-  latest_release: '2023'
-  platforms: 'linux/amd64, linux/arm64'
-  registry: 'quay.io/toolbx-images'
 
 # Prevent multiple workflow runs from racing to ensure that pushes are made
 # sequentially for the main branch. Also cancel in progress workflow runs for
@@ -34,91 +29,14 @@ concurrency:
 
 jobs:
   build-push-images:
-    strategy:
-      fail-fast: false
-      matrix:
-        release: ['2', '2023']
-
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU for multi-arch builds
-        shell: bash
-        run: |
-          sudo apt update
-          sudo apt install qemu-user-static
-
-      - name: Build container image
-        uses: redhat-actions/buildah-build@v2
-        if: env.latest_release != matrix.release
-        with:
-          platforms: ${{ env.platforms }}
-          context: ${{ env.distro }}/${{ matrix.release }}
-          image: ${{ env.distro }}-toolbox
-          tags: ${{ matrix.release }}
-          containerfiles: ${{ env.distro }}/${{ matrix.release }}/Containerfile
-          layers: false
-          oci: true
-
-      - name: Build container image (latest tag)
-        uses: redhat-actions/buildah-build@v2
-        if: env.latest_release == matrix.release
-        with:
-          platforms: ${{ env.platforms }}
-          context: ${{ env.distro }}/${{ matrix.release }}
-          image: ${{ env.distro }}-toolbox
-          tags: ${{ matrix.release }} latest
-          containerfiles: ${{ env.distro }}/${{ matrix.release }}/Containerfile
-          layers: false
-          oci: true
-
-      - name: Push to Container Registry
-        uses: redhat-actions/push-to-registry@v2
-        id: push
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release != matrix.release
-        with:
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-          image: ${{ env.distro }}-toolbox
-          registry: ${{ env.registry }}
-          tags: ${{ matrix.release }}
-
-      - name: Push to Container Registry (latest tag)
-        uses: redhat-actions/push-to-registry@v2
-        id: push-latest
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release == matrix.release
-        with:
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-          image: ${{ env.distro }}-toolbox
-          registry: ${{ env.registry }}
-          tags: ${{ matrix.release }} latest
-
-      - name: Login to Container Registry
-        uses: redhat-actions/podman-login@v1
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
-        with:
-          registry: ${{ env.registry }}
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-
-      - uses: sigstore/cosign-installer@v3.3.0
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
-
-      - name: Sign container image
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release != matrix.release
-        run: |
-          cosign sign -y --recursive --key env://COSIGN_PRIVATE_KEY ${{ env.registry }}/${{ env.distro }}-toolbox@${{ steps.push.outputs.digest }}
-        env:
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
-
-      - name: Sign container image (latest)
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release == matrix.release
-        run: |
-          cosign sign -y --recursive --key env://COSIGN_PRIVATE_KEY ${{ env.registry }}/${{ env.distro }}-toolbox@${{ steps.push-latest.outputs.digest }}
-        env:
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+    uses: ./.github/workflows/build-push-images.yaml
+    with:
+      distro: amazonlinux
+      releases: 2 2023
+      latest-release: 2023
+      registry: quay.io/toolbx-images
+      platforms: linux/amd64, linux/arm64
+    secrets:
+      registry-user: ${{ secrets.BOT_USERNAME }}
+      registry-password: ${{ secrets.BOT_PASSWORD }}
+      cosign-private-key: ${{ secrets.COSIGN_PRIVATE_KEY }}

--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -46,6 +46,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       releases: ${{ steps.context.outputs.releases }}
+      timestamp: ${{ steps.context.outputs.timestamp }}
     steps:
       - uses: actions/github-script@v7
         id: context
@@ -54,7 +55,9 @@ jobs:
         with:
           script: |
             const releases = process.env.RELEASES.split(/\s+/);
+            const timestamp = Math.floor(Date.now() / 1000);
             core.setOutput('releases', JSON.stringify(releases));
+            core.setOutput('timestamp', timestamp);
 
   build-and-push:
     needs: [context]
@@ -64,7 +67,7 @@ jobs:
         release: ${{ fromJSON(needs.context.outputs.releases) }}
         include:
           - release: ${{ inputs.latest-release }}
-            extra-tag: latest
+            extra-tag: latest latest-${{ needs.context.outputs.timestamp }}
 
     runs-on: ubuntu-24.04
     steps:
@@ -83,7 +86,10 @@ jobs:
           platforms: ${{ inputs.platforms }}
           context: ${{ inputs.distro }}/${{ matrix.release }}
           image: ${{ inputs.distro }}-toolbox
-          tags: ${{ matrix.release }} ${{ matrix.extra-tag }}
+          tags: |
+            ${{ matrix.release }}
+            ${{ matrix.release }}-${{ needs.context.outputs.timestamp }}
+            ${{ matrix.extra-tag }}
           containerfiles: ${{ inputs.distro }}/${{ matrix.release }}/Containerfile
           layers: false
           oci: true
@@ -103,7 +109,10 @@ jobs:
         with:
           image: ${{ inputs.distro }}-toolbox
           registry: ${{ inputs.registry }}
-          tags: ${{ matrix.release }} ${{ matrix.extra-tag }}
+          tags: |
+            ${{ matrix.release }}
+            ${{ matrix.release }}-${{ needs.context.outputs.timestamp }}
+            ${{ matrix.extra-tag }}
 
       - uses: sigstore/cosign-installer@v3.3.0
         if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'

--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -1,0 +1,117 @@
+name: Build and push toolbx images
+
+on:
+  workflow_call:
+    inputs:
+      distro:
+        description: Distribution to build for
+        required: true
+        type: string
+
+      releases:
+        description: Distribution releases to build, separated by space
+        required: true
+        type: string
+
+      latest-release:
+        description: Distribution release to be tagged 'latest'
+        required: true
+        type: string
+
+      registry:
+        description: Registry to push to
+        required: true
+        type: string
+
+      platforms:
+        description: Build images for the given platforms, separated by comma
+        required: false
+        type: string
+
+    secrets:
+      registry-user:
+        description: Username used to log into registry
+        required: true
+
+      registry-password:
+        description: Password used to log into registry
+        required: true
+
+      cosign-private-key:
+        description: Private key to sign containers with
+        required: true
+
+jobs:
+  context:
+    runs-on: ubuntu-24.04
+    outputs:
+      releases: ${{ steps.context.outputs.releases }}
+    steps:
+      - uses: actions/github-script@v7
+        id: context
+        env:
+          RELEASES: ${{ inputs.releases }}
+        with:
+          script: |
+            const releases = process.env.RELEASES.split(/\s+/);
+            core.setOutput('releases', JSON.stringify(releases));
+
+  build-and-push:
+    needs: [context]
+    strategy:
+      fail-fast: false
+      matrix:
+        release: ${{ fromJSON(needs.context.outputs.releases) }}
+        include:
+          - release: ${{ inputs.latest-release }}
+            extra-tag: latest
+
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU for multi-arch builds
+        shell: bash
+        run: |
+          sudo apt update
+          sudo apt install qemu-user-static
+
+      - name: Build container image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          platforms: ${{ inputs.platforms }}
+          context: ${{ inputs.distro }}/${{ matrix.release }}
+          image: ${{ inputs.distro }}-toolbox
+          tags: ${{ matrix.release }} ${{ matrix.extra-tag }}
+          containerfiles: ${{ inputs.distro }}/${{ matrix.release }}/Containerfile
+          layers: false
+          oci: true
+
+      - name: Login to Container Registry
+        uses: redhat-actions/podman-login@v1
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ secrets.registry-user }}
+          password: ${{ secrets.registry-password }}
+
+      - name: Push to Container Registry
+        uses: redhat-actions/push-to-registry@v2
+        id: push
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
+        with:
+          image: ${{ inputs.distro }}-toolbox
+          registry: ${{ inputs.registry }}
+          tags: ${{ matrix.release }} ${{ matrix.extra-tag }}
+
+      - uses: sigstore/cosign-installer@v3.3.0
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
+
+      - name: Sign container image
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
+        run: |
+          cosign sign -y --recursive --key env://COSIGN_PRIVATE_KEY ${{ inputs.registry }}/${{ inputs.distro }}-toolbox@${{ steps.push.outputs.digest }}
+        env:
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_PRIVATE_KEY: ${{ secrets.cosign-private-key }}

--- a/.github/workflows/centos.yaml
+++ b/.github/workflows/centos.yaml
@@ -9,21 +9,16 @@ on:
     paths:
       - centos/**
       - .github/workflows/centos.yaml
+      - .github/workflows/build-push-images.yaml
   push:
     branches:
       - main
     paths:
       - centos/**
       - .github/workflows/centos.yaml
+      - .github/workflows/build-push-images.yaml
   schedule:
     - cron:  '0 0 * * MON'
-
-env:
-  distro: 'centos'
-  distro_pretty: 'CentOS'
-  latest_release: 'stream10'
-  platforms: 'linux/amd64, linux/arm64'
-  registry: 'quay.io/toolbx-images'
 
 # Prevent multiple workflow runs from racing to ensure that pushes are made
 # sequentially for the main branch. Also cancel in progress workflow runs for
@@ -34,91 +29,14 @@ concurrency:
 
 jobs:
   build-push-images:
-    strategy:
-      fail-fast: false
-      matrix:
-        release: ['stream9', 'stream10']
-
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU for multi-arch builds
-        shell: bash
-        run: |
-          sudo apt update
-          sudo apt install qemu-user-static
-
-      - name: Build container image
-        uses: redhat-actions/buildah-build@v2
-        if: env.latest_release != matrix.release
-        with:
-          platforms: ${{ env.platforms }}
-          context: ${{ env.distro }}/${{ matrix.release }}
-          image: ${{ env.distro }}-toolbox
-          tags: ${{ matrix.release }}
-          containerfiles: ${{ env.distro }}/${{ matrix.release }}/Containerfile
-          layers: false
-          oci: true
-
-      - name: Build container image (latest tag)
-        uses: redhat-actions/buildah-build@v2
-        if: env.latest_release == matrix.release
-        with:
-          platforms: ${{ env.platforms }}
-          context: ${{ env.distro }}/${{ matrix.release }}
-          image: ${{ env.distro }}-toolbox
-          tags: ${{ matrix.release }} latest
-          containerfiles: ${{ env.distro }}/${{ matrix.release }}/Containerfile
-          layers: false
-          oci: true
-
-      - name: Push to Container Registry
-        uses: redhat-actions/push-to-registry@v2
-        id: push
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release != matrix.release
-        with:
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-          image: ${{ env.distro }}-toolbox
-          registry: ${{ env.registry }}
-          tags: ${{ matrix.release }}
-
-      - name: Push to Container Registry (latest tag)
-        uses: redhat-actions/push-to-registry@v2
-        id: push-latest
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release == matrix.release
-        with:
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-          image: ${{ env.distro }}-toolbox
-          registry: ${{ env.registry }}
-          tags: ${{ matrix.release }} latest
-
-      - name: Login to Container Registry
-        uses: redhat-actions/podman-login@v1
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
-        with:
-          registry: ${{ env.registry }}
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-
-      - uses: sigstore/cosign-installer@v3.3.0
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
-
-      - name: Sign container image
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release != matrix.release
-        run: |
-          cosign sign -y --recursive --key env://COSIGN_PRIVATE_KEY ${{ env.registry }}/${{ env.distro }}-toolbox@${{ steps.push.outputs.digest }}
-        env:
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
-
-      - name: Sign container image (latest)
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release == matrix.release
-        run: |
-          cosign sign -y --recursive --key env://COSIGN_PRIVATE_KEY ${{ env.registry }}/${{ env.distro }}-toolbox@${{ steps.push-latest.outputs.digest }}
-        env:
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+    uses: ./.github/workflows/build-push-images.yaml
+    with:
+      distro: centos
+      releases: stream9 stream10
+      latest-release: stream10
+      registry: quay.io/toolbx-images
+      platforms: linux/amd64, linux/arm64
+    secrets:
+      registry-user: ${{ secrets.BOT_USERNAME }}
+      registry-password: ${{ secrets.BOT_PASSWORD }}
+      cosign-private-key: ${{ secrets.COSIGN_PRIVATE_KEY }}

--- a/.github/workflows/debian.yaml
+++ b/.github/workflows/debian.yaml
@@ -9,21 +9,16 @@ on:
     paths:
       - debian/**
       - .github/workflows/debian.yaml
+      - .github/workflows/build-push-images.yaml
   push:
     branches:
       - main
     paths:
       - debian/**
       - .github/workflows/debian.yaml
+      - .github/workflows/build-push-images.yaml
   schedule:
     - cron:  '0 0 * * MON'
-
-env:
-  distro: 'debian'
-  distro_pretty: 'Debian'
-  latest_release: 'unstable'
-  platforms: 'linux/amd64, linux/arm64'
-  registry: 'quay.io/toolbx-images'
 
 # Prevent multiple workflow runs from racing to ensure that pushes are made
 # sequentially for the main branch. Also cancel in progress workflow runs for
@@ -34,91 +29,14 @@ concurrency:
 
 jobs:
   build-push-images:
-    strategy:
-      fail-fast: false
-      matrix:
-        release: ['10', '11', '12', 'testing', 'unstable']
-
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU for multi-arch builds
-        shell: bash
-        run: |
-          sudo apt update
-          sudo apt install qemu-user-static
-
-      - name: Build container image
-        uses: redhat-actions/buildah-build@v2
-        if: env.latest_release != matrix.release
-        with:
-          platforms: ${{ env.platforms }}
-          context: ${{ env.distro }}/${{ matrix.release }}
-          image: ${{ env.distro }}-toolbox
-          tags: ${{ matrix.release }}
-          containerfiles: ${{ env.distro }}/${{ matrix.release }}/Containerfile
-          layers: false
-          oci: true
-
-      - name: Build container image (latest tag)
-        uses: redhat-actions/buildah-build@v2
-        if: env.latest_release == matrix.release
-        with:
-          platforms: ${{ env.platforms }}
-          context: ${{ env.distro }}/${{ matrix.release }}
-          image: ${{ env.distro }}-toolbox
-          tags: ${{ matrix.release }} latest
-          containerfiles: ${{ env.distro }}/${{ matrix.release }}/Containerfile
-          layers: false
-          oci: true
-
-      - name: Push to Container Registry
-        uses: redhat-actions/push-to-registry@v2
-        id: push
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release != matrix.release
-        with:
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-          image: ${{ env.distro }}-toolbox
-          registry: ${{ env.registry }}
-          tags: ${{ matrix.release }}
-
-      - name: Push to Container Registry (latest tag)
-        uses: redhat-actions/push-to-registry@v2
-        id: push-latest
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release == matrix.release
-        with:
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-          image: ${{ env.distro }}-toolbox
-          registry: ${{ env.registry }}
-          tags: ${{ matrix.release }} latest
-
-      - name: Login to Container Registry
-        uses: redhat-actions/podman-login@v1
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
-        with:
-          registry: ${{ env.registry }}
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-
-      - uses: sigstore/cosign-installer@v3.3.0
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
-
-      - name: Sign container image
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release != matrix.release
-        run: |
-          cosign sign -y --recursive --key env://COSIGN_PRIVATE_KEY ${{ env.registry }}/${{ env.distro }}-toolbox@${{ steps.push.outputs.digest }}
-        env:
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
-
-      - name: Sign container image (latest)
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release == matrix.release
-        run: |
-          cosign sign -y --recursive --key env://COSIGN_PRIVATE_KEY ${{ env.registry }}/${{ env.distro }}-toolbox@${{ steps.push-latest.outputs.digest }}
-        env:
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+    uses: ./.github/workflows/build-push-images.yaml
+    with:
+      distro: debian
+      releases: 10 11 12 testing unstable
+      latest-release: unstable
+      registry: quay.io/toolbx-images
+      platforms: linux/amd64, linux/arm64
+    secrets:
+      registry-user: ${{ secrets.BOT_USERNAME }}
+      registry-password: ${{ secrets.BOT_PASSWORD }}
+      cosign-private-key: ${{ secrets.COSIGN_PRIVATE_KEY }}

--- a/.github/workflows/opensuse.yaml
+++ b/.github/workflows/opensuse.yaml
@@ -9,21 +9,16 @@ on:
     paths:
       - opensuse/**
       - .github/workflows/opensuse.yaml
+      - .github/workflows/build-push-images.yaml
   push:
     branches:
       - main
     paths:
       - opensuse/**
       - .github/workflows/opensuse.yaml
+      - .github/workflows/build-push-images.yaml
   schedule:
     - cron:  '0 0 * * MON'
-
-env:
-  distro: 'opensuse'
-  distro_pretty: 'openSUSE'
-  latest_release: 'tumbleweed'
-  platforms: 'linux/amd64, linux/arm64'
-  registry: 'quay.io/toolbx-images'
 
 # Prevent multiple workflow runs from racing to ensure that pushes are made
 # sequentially for the main branch. Also cancel in progress workflow runs for
@@ -34,90 +29,14 @@ concurrency:
 
 jobs:
   build-push-images:
-    strategy:
-      matrix:
-        release: ['tumbleweed']
-
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU for multi-arch builds
-        shell: bash
-        run: |
-          sudo apt update
-          sudo apt install qemu-user-static
-
-      - name: Build container image
-        uses: redhat-actions/buildah-build@v2
-        if: env.latest_release != matrix.release
-        with:
-          platforms: ${{ env.platforms }}
-          context: ${{ env.distro }}/${{ matrix.release }}
-          image: ${{ env.distro }}-toolbox
-          tags: ${{ matrix.release }}
-          containerfiles: ${{ env.distro }}/${{ matrix.release }}/Containerfile
-          layers: false
-          oci: true
-
-      - name: Build container image (latest tag)
-        uses: redhat-actions/buildah-build@v2
-        if: env.latest_release == matrix.release
-        with:
-          platforms: ${{ env.platforms }}
-          context: ${{ env.distro }}/${{ matrix.release }}
-          image: ${{ env.distro }}-toolbox
-          tags: ${{ matrix.release }} latest
-          containerfiles: ${{ env.distro }}/${{ matrix.release }}/Containerfile
-          layers: false
-          oci: true
-
-      - name: Push to Container Registry
-        uses: redhat-actions/push-to-registry@v2
-        id: push
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release != matrix.release
-        with:
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-          image: ${{ env.distro }}-toolbox
-          registry: ${{ env.registry }}
-          tags: ${{ matrix.release }}
-
-      - name: Push to Container Registry (latest tag)
-        uses: redhat-actions/push-to-registry@v2
-        id: push-latest
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release == matrix.release
-        with:
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-          image: ${{ env.distro }}-toolbox
-          registry: ${{ env.registry }}
-          tags: ${{ matrix.release }} latest
-
-      - name: Login to Container Registry
-        uses: redhat-actions/podman-login@v1
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
-        with:
-          registry: ${{ env.registry }}
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-
-      - uses: sigstore/cosign-installer@v3.3.0
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
-
-      - name: Sign container image
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release != matrix.release
-        run: |
-          cosign sign -y --recursive --key env://COSIGN_PRIVATE_KEY ${{ env.registry }}/${{ env.distro }}-toolbox@${{ steps.push.outputs.digest }}
-        env:
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
-
-      - name: Sign container image (latest)
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release == matrix.release
-        run: |
-          cosign sign -y --recursive --key env://COSIGN_PRIVATE_KEY ${{ env.registry }}/${{ env.distro }}-toolbox@${{ steps.push-latest.outputs.digest }}
-        env:
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+    uses: ./.github/workflows/build-push-images.yaml
+    with:
+      distro: opensuse
+      releases: tumbleweed
+      latest-release: tumbleweed
+      registry: quay.io/toolbx-images
+      platforms: linux/amd64, linux/arm64
+    secrets:
+      registry-user: ${{ secrets.BOT_USERNAME }}
+      registry-password: ${{ secrets.BOT_PASSWORD }}
+      cosign-private-key: ${{ secrets.COSIGN_PRIVATE_KEY }}

--- a/.github/workflows/rockylinux.yaml
+++ b/.github/workflows/rockylinux.yaml
@@ -9,21 +9,16 @@ on:
     paths:
       - rockylinux/**
       - .github/workflows/rockylinux.yaml
+      - .github/workflows/build-push-images.yaml
   push:
     branches:
       - main
     paths:
       - rockylinux/**
       - .github/workflows/rockylinux.yaml
+      - .github/workflows/build-push-images.yaml
   schedule:
     - cron:  '0 0 * * MON'
-
-env:
-  distro: 'rockylinux'
-  distro_pretty: 'Rocky Linux'
-  latest_release: '9'
-  platforms: 'linux/amd64, linux/arm64'
-  registry: 'quay.io/toolbx-images'
 
 # Prevent multiple workflow runs from racing to ensure that pushes are made
 # sequentially for the main branch. Also cancel in progress workflow runs for
@@ -34,91 +29,14 @@ concurrency:
 
 jobs:
   build-push-images:
-    strategy:
-      fail-fast: false
-      matrix:
-        release: ['8', '9']
-
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU for multi-arch builds
-        shell: bash
-        run: |
-          sudo apt update
-          sudo apt install qemu-user-static
-
-      - name: Build container image
-        uses: redhat-actions/buildah-build@v2
-        if: env.latest_release != matrix.release
-        with:
-          platforms: ${{ env.platforms }}
-          context: ${{ env.distro }}/${{ matrix.release }}
-          image: ${{ env.distro }}-toolbox
-          tags: ${{ matrix.release }}
-          containerfiles: ${{ env.distro }}/${{ matrix.release }}/Containerfile
-          layers: false
-          oci: true
-
-      - name: Build container image (latest tag)
-        uses: redhat-actions/buildah-build@v2
-        if: env.latest_release == matrix.release
-        with:
-          platforms: ${{ env.platforms }}
-          context: ${{ env.distro }}/${{ matrix.release }}
-          image: ${{ env.distro }}-toolbox
-          tags: ${{ matrix.release }} latest
-          containerfiles: ${{ env.distro }}/${{ matrix.release }}/Containerfile
-          layers: false
-          oci: true
-
-      - name: Push to Container Registry
-        uses: redhat-actions/push-to-registry@v2
-        id: push
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release != matrix.release
-        with:
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-          image: ${{ env.distro }}-toolbox
-          registry: ${{ env.registry }}
-          tags: ${{ matrix.release }}
-
-      - name: Push to Container Registry (latest tag)
-        uses: redhat-actions/push-to-registry@v2
-        id: push-latest
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release == matrix.release
-        with:
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-          image: ${{ env.distro }}-toolbox
-          registry: ${{ env.registry }}
-          tags: ${{ matrix.release }} latest
-
-      - name: Login to Container Registry
-        uses: redhat-actions/podman-login@v1
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
-        with:
-          registry: ${{ env.registry }}
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-
-      - uses: sigstore/cosign-installer@v3.3.0
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
-
-      - name: Sign container image
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release != matrix.release
-        run: |
-          cosign sign -y --recursive --key env://COSIGN_PRIVATE_KEY ${{ env.registry }}/${{ env.distro }}-toolbox@${{ steps.push.outputs.digest }}
-        env:
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
-
-      - name: Sign container image (latest)
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release == matrix.release
-        run: |
-          cosign sign -y --recursive --key env://COSIGN_PRIVATE_KEY ${{ env.registry }}/${{ env.distro }}-toolbox@${{ steps.push-latest.outputs.digest }}
-        env:
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+    uses: ./.github/workflows/build-push-images.yaml
+    with:
+      distro: rockylinux
+      releases: 8 9
+      latest-release: 9
+      registry: quay.io/toolbx-images
+      platforms: linux/amd64, linux/arm64
+    secrets:
+      registry-user: ${{ secrets.BOT_USERNAME }}
+      registry-password: ${{ secrets.BOT_PASSWORD }}
+      cosign-private-key: ${{ secrets.COSIGN_PRIVATE_KEY }}

--- a/.github/workflows/wolfi.yaml
+++ b/.github/workflows/wolfi.yaml
@@ -9,21 +9,16 @@ on:
     paths:
       - wolfi/**
       - .github/workflows/wolfi.yaml
+      - .github/workflows/build-push-images.yaml
   push:
     branches:
       - main
     paths:
       - wolfi/**
       - .github/workflows/wolfi.yaml
+      - .github/workflows/build-push-images.yaml
   schedule:
     - cron:  '0 0 * * MON'
-
-env:
-  distro: 'wolfi'
-  distro_pretty: 'wolfi Linux'
-  latest_release: 'latest'
-  platforms: 'linux/amd64, linux/arm64'
-  registry: 'quay.io/toolbx-images'
 
 # Prevent multiple workflow runs from racing to ensure that pushes are made
 # sequentially for the main branch. Also cancel in progress workflow runs for
@@ -34,90 +29,14 @@ concurrency:
 
 jobs:
   build-push-images:
-    strategy:
-      matrix:
-        release: ['latest']
-
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU for multi-arch builds
-        shell: bash
-        run: |
-          sudo apt update
-          sudo apt install qemu-user-static
-
-      - name: Build container image
-        uses: redhat-actions/buildah-build@v2
-        if: env.latest_release != matrix.release
-        with:
-          platforms: ${{ env.platforms }}
-          context: ${{ env.distro }}/${{ matrix.release }}
-          image: ${{ env.distro }}-toolbox
-          tags: ${{ matrix.release }}
-          containerfiles: ${{ env.distro }}/${{ matrix.release }}/Containerfile
-          layers: false
-          oci: true
-
-      - name: Build container image (latest tag)
-        uses: redhat-actions/buildah-build@v2
-        if: env.latest_release == matrix.release
-        with:
-          platforms: ${{ env.platforms }}
-          context: ${{ env.distro }}/${{ matrix.release }}
-          image: ${{ env.distro }}-toolbox
-          tags: ${{ matrix.release }} latest
-          containerfiles: ${{ env.distro }}/${{ matrix.release }}/Containerfile
-          layers: false
-          oci: true
-
-      - name: Push to Container Registry
-        uses: redhat-actions/push-to-registry@v2
-        id: push
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release != matrix.release
-        with:
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-          image: ${{ env.distro }}-toolbox
-          registry: ${{ env.registry }}
-          tags: ${{ matrix.release }}
-
-      - name: Push to Container Registry (latest tag)
-        uses: redhat-actions/push-to-registry@v2
-        id: push-latest
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release == matrix.release
-        with:
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-          image: ${{ env.distro }}-toolbox
-          registry: ${{ env.registry }}
-          tags: ${{ matrix.release }} latest
-
-      - name: Login to Container Registry
-        uses: redhat-actions/podman-login@v1
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
-        with:
-          registry: ${{ env.registry }}
-          username: ${{ secrets.BOT_USERNAME }}
-          password: ${{ secrets.BOT_SECRET }}
-
-      - uses: sigstore/cosign-installer@v3.3.0
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main'
-
-      - name: Sign container image
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release != matrix.release
-        run: |
-          cosign sign -y --recursive --key env://COSIGN_PRIVATE_KEY ${{ env.registry }}/${{ env.distro }}-toolbox@${{ steps.push.outputs.digest }}
-        env:
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
-
-      - name: Sign container image (latest)
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && env.latest_release == matrix.release
-        run: |
-          cosign sign -y --recursive --key env://COSIGN_PRIVATE_KEY ${{ env.registry }}/${{ env.distro }}-toolbox@${{ steps.push-latest.outputs.digest }}
-        env:
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+    uses: ./.github/workflows/build-push-images.yaml
+    with:
+      distro: wolfi
+      releases: latest
+      latest-release: latest
+      registry: quay.io/toolbx-images
+      platforms: linux/amd64, linux/arm64
+    secrets:
+      registry-user: ${{ secrets.BOT_USERNAME }}
+      registry-password: ${{ secrets.BOT_PASSWORD }}
+      cosign-private-key: ${{ secrets.COSIGN_PRIVATE_KEY }}


### PR DESCRIPTION
This PR move image building logic into a reusable workflow, simplifying CI modification for all images. Additionally, all images are now versioned using UNIX epoch at time-of-build.

Fixes: https://github.com/toolbx-images/images/issues/148