### PR TITLE
Remove DEBIAN_FRONTEND=noninteractive from apt-get invocation

### DIFF
--- a/debian/10/Containerfile
+++ b/debian/10/Containerfile
@@ -23,7 +23,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Install extra packages as well as libnss-myhostname
 COPY extra-packages /
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    apt-get -y install \
         libnss-myhostname \
         $(cat extra-packages | xargs) && \
     rm -rd /var/lib/apt/lists/*

--- a/debian/11/Containerfile
+++ b/debian/11/Containerfile
@@ -23,7 +23,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Install extra packages as well as libnss-myhostname
 COPY extra-packages /
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    apt-get -y install \
         libnss-myhostname \
         $(cat extra-packages | xargs) && \
     rm -rd /var/lib/apt/lists/*

--- a/debian/12/Containerfile
+++ b/debian/12/Containerfile
@@ -23,7 +23,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Install extra packages as well as libnss-myhostname
 COPY extra-packages /
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    apt-get -y install \
         libnss-myhostname \
         $(cat extra-packages | xargs) && \
     rm -rd /var/lib/apt/lists/*

--- a/debian/testing/Containerfile
+++ b/debian/testing/Containerfile
@@ -23,7 +23,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Install extra packages as well as libnss-myhostname
 COPY extra-packages /
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    apt-get -y install \
         libnss-myhostname \
         $(cat extra-packages | xargs) && \
     rm -rd /var/lib/apt/lists/*

--- a/debian/unstable/Containerfile
+++ b/debian/unstable/Containerfile
@@ -23,7 +23,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Install extra packages as well as libnss-myhostname
 COPY extra-packages /
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    apt-get -y install \
         libnss-myhostname \
         $(cat extra-packages | xargs) && \
     rm -rd /var/lib/apt/lists/*


### PR DESCRIPTION
This is set by the `ARG` directive just above this command.