### PR TITLE
Add p11-kit-client.so to newer Debian images

### DIFF
--- a/debian/11/extra-packages
+++ b/debian/11/extra-packages
@@ -22,6 +22,7 @@ manpages
 mtr
 nano
 openssh-client
+p11-kit-modules
 passwd
 pigz
 procps

--- a/debian/12/extra-packages
+++ b/debian/12/extra-packages
@@ -22,6 +22,7 @@ manpages
 mtr
 nano
 openssh-client
+p11-kit-modules
 passwd
 pigz
 procps

--- a/debian/13/extra-packages
+++ b/debian/13/extra-packages
@@ -22,6 +22,7 @@ manpages
 mtr
 nano
 openssh-client
+p11-kit-modules
 passwd
 pigz
 procps

--- a/debian/testing/extra-packages
+++ b/debian/testing/extra-packages
@@ -22,6 +22,7 @@ manpages
 mtr
 nano
 openssh-client
+p11-kit-modules
 passwd
 pigz
 procps

--- a/debian/unstable/extra-packages
+++ b/debian/unstable/extra-packages
@@ -22,6 +22,7 @@ manpages
 mtr
 nano
 openssh-client
+p11-kit-modules
 passwd
 pigz
 procps


### PR DESCRIPTION
Apply changes from https://github.com/containers/toolbox/commit/aa8507730d:

> Toolbx can use to give Toolbx containers access to the certificates from certificate authorities on the host.
> 
> p11-kit-client.so was introduced in p11-kit 0.23.10 ([1]). Therefore, this feature is only enabled for Debian 11 and newer.
> 
> [1]: https://github.com/p11-glue/p11-kit/commit/0684cd7b7f815b41
> https://github.com/p11-glue/p11-kit/pull/15
> 
> https://github.com/containers/toolbox/issues/626