### PR TITLE
ci: add debian 13 to the build pipeline

### DIFF
--- a/.github/workflows/debian.yaml
+++ b/.github/workflows/debian.yaml
@@ -32,7 +32,7 @@ jobs:
     uses: ./.github/workflows/build-push-images.yaml
     with:
       distro: debian
-      releases: 11 12 testing unstable
+      releases: 11 12 13 testing unstable
       latest-release: unstable
       registry: quay.io/toolbx-images
       platforms: linux/amd64, linux/arm64

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ directly use the commands below:
   $ toolbox create --image quay.io/toolbx-images/debian-toolbox:testing
   $ toolbox enter debian-toolbox-testing
 
+  $ toolbox create --image quay.io/toolbx-images/debian-toolbox:13
+  $ toolbox enter debian-toolbox-13
+
   $ toolbox create --image quay.io/toolbx-images/debian-toolbox:12
   $ toolbox enter debian-toolbox-12
 


### PR DESCRIPTION
My bad: I forgot to add the Debian 13 image to the pipeline. :-)