### PR TITLE
ci: s390x/ppc64le for CentOS

### DIFF
--- a/.github/workflows/centos.yaml
+++ b/.github/workflows/centos.yaml
@@ -35,7 +35,7 @@ jobs:
       releases: stream9 stream10
       latest-release: stream10
       registry: quay.io/toolbx-images
-      platforms: linux/amd64, linux/arm64
+      platforms: linux/amd64, linux/arm64, linux/s390x, linux/ppc64le
     secrets:
       registry-user: ${{ secrets.BOT_USERNAME }}
       registry-password: ${{ secrets.BOT_PASSWORD }}


### PR DESCRIPTION
Enable cross-architecture builds for the additional s390x and ppc64le architectures.

For my build pipelines I use toolbx images as bootstrap roots for cross-architecture building so this might be a bit of a self-serving PR but perhaps it is also useful to others :)